### PR TITLE
Exclude Makefile.toml from published crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 description = "A simple, inefficient Future executor"
 license = "Apache-2.0 OR MIT"
 categories = ["asynchronous", "no-std"]
+exclude = ["/Makefile.toml"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
It looks like this file is not useful to users or downstream projects, so I suggest to exclude it from crates that are published to crates.io.