### PR TITLE
Remove the one dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,8 +7,4 @@ description = "A simple, inefficient Future executor"
 license = "Apache-2.0 OR MIT"
 categories = ["asynchronous", "no-std"]
 exclude = ["/Makefile.toml"]
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
-[dependencies]
-pin-utils = "0.1.0"
+repository = "https://github.com/paulkernfeld/spin_on"

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The advantages of this crate are:
 - It is really simple
 - It should work on basically any platform
 - It has no dependency on `std` or on an allocator
-- It only has one dependency
+- It has no dependencies
 
 ### The Design
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,7 +72,7 @@ fn noop_waker() -> RawWaker {
 /// Continuously poll a future until it returns `Poll::Ready`. This is not normally how an
 /// executor should work, because it runs the CPU at 100%.
 pub fn spin_on<F: Future>(mut future: F) -> F::Output {
-    let future = unsafe { Pin::new_unchecked(&mut future) };
+    let mut future = unsafe { Pin::new_unchecked(&mut future) };
     let waker = &unsafe { Waker::from_raw(noop_waker()) };
     let mut cx = Context::from_waker(waker);
     loop {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@
 //! - It is really simple
 //! - It should work on basically any platform
 //! - It has no dependency on `std` or on an allocator
-//! - It only has one dependency
+//! - It has no dependencies
 //!
 //! ## The Design
 //!


### PR DESCRIPTION
This crate has one dependency: `pin_utils`. From this crate, it uses one macro, `pin_mut`, which expands to the following:

```
let mut $x = x;
let $x = Pin::unchecked_new(&mut x);
```

I inline this macro in the one place where it's used (the spin_on function), therefore eliminating the aforementioned dependency.